### PR TITLE
ci: enable `dependabot`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+    - package-ecosystem: "gomod"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"


### PR DESCRIPTION
The main motivation is to avoid dependencies becoming too outdated.

Configuration was copied from
https://github.com/nlnwa/go_container/blob/712d97712de12bdf76910f31cc5f9d177ff8acb0/.github/dependabot.yaml The only difference is that `dockerfile` configuration has been removed as it is not relevant for this project.