### PR TITLE
ci: run test workflow on push

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: test
 
 on:
-  pull_request: { }
+  push:
 
 permissions:
   contents: read


### PR DESCRIPTION
Without this change the test workflow is only run on pull requests. Which makes it annoying to test changes during development, as you would always need to create a pull request first.