### PR TITLE
build: rename default branch to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Veidemannctl
 
-[![License Apache](https://img.shields.io/github/license/nlnwa/veidemannctl.svg)](https://github.com/nlnwa/veidemannctl/blob/master/LICENSE)
+[![License Apache](https://img.shields.io/github/license/nlnwa/veidemannctl.svg)](https://github.com/nlnwa/veidemannctl/blob/main/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/nlnwa/veidemannctl.svg)](https://github.com/nlnwa/veidemannctl/releases/latest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/nlnwa/veidemannctl?style=flat-square)](https://goreportcard.com/report/github.com/nlnwa/veidemannctl)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/nlnwa/veidemannctl)](https://pkg.go.dev/github.com/nlnwa/veidemannctl)
@@ -10,7 +10,7 @@
 Install the latest release version
 
 ```console
-curl -sL https://raw.githubusercontent.com/nlnwa/veidemannctl/master/install.sh | bash
+curl -sL https://raw.githubusercontent.com/nlnwa/veidemannctl/main/install.sh | bash
 ```
 
 ## Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ A command line client for Veidemann
 Install the latest release version (currently only for linux/amd64)
 
 ```console
-curl -sL https://raw.githubusercontent.com/nlnwa/veidemannctl/master/install.sh | bash
+curl -sL https://raw.githubusercontent.com/nlnwa/veidemannctl/main/install.sh | bash
 ```
 
 ## Documentation


### PR DESCRIPTION
This is one step to standardize the default branch names across all repositories. The next step is to rename the default branch to `main` in the GitHub repository settings.

Should be merged after https://github.com/nlnwa/veidemannctl/pull/49