### PR TITLE
Normalization of dates in responses from query command

### DIFF
--- a/cmd/report/query.go
+++ b/cmd/report/query.go
@@ -59,7 +59,7 @@ func (o *queryCmdOptions) run() error {
 	}
 
 	request := reportV1.ExecuteDbQueryRequest{
-		Query: q.query,
+		Query: q.Query,
 		Limit: o.pageSize,
 	}
 
@@ -77,10 +77,10 @@ func (o *queryCmdOptions) run() error {
 	}
 
 	var formatter format.Formatter
-	if q.template == "" {
+	if q.Template == "" {
 		formatter, err = format.NewFormatter("", w, o.format, o.goTemplate)
 	} else {
-		formatter, err = format.NewFormatter("", w, "template", q.template)
+		formatter, err = format.NewFormatter("", w, "template", q.Template)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to create formatter: %w", err)
@@ -131,8 +131,8 @@ func newQueryCmd() *cobra.Command {
 			q := listStoredQueries(d)
 			var names []string
 			for _, s := range q {
-				if strings.HasPrefix(s.name, toComplete) {
-					names = append(names, s.name+"\t"+s.description)
+				if strings.HasPrefix(s.Name, toComplete) {
+					names = append(names, s.Name+"\t"+s.Description)
 				}
 			}
 			return names, cobra.ShellCompDirectiveDefault
@@ -157,10 +157,10 @@ func newQueryCmd() *cobra.Command {
 
 // query is a struct for holding query definitions
 type query struct {
-	name        string
-	description string
-	query       string
-	template    string
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Query       string `json:"query"`
+	Template    string `json:"template"`
 }
 
 func (o *queryCmdOptions) parseQuery() (*query, error) {
@@ -168,7 +168,7 @@ func (o *queryCmdOptions) parseQuery() (*query, error) {
 
 	if strings.HasPrefix(o.queryOrFile, "r.") {
 		q = &query{
-			query: o.queryOrFile,
+			Query: o.queryOrFile,
 		}
 	} else {
 		filename, err := findQueryFile(o.queryOrFile)
@@ -182,7 +182,7 @@ func (o *queryCmdOptions) parseQuery() (*query, error) {
 		}
 	}
 
-	q.query = fmt.Sprintf(q.query, o.queryArgs...)
+	q.Query = fmt.Sprintf(q.Query, o.queryArgs...)
 
 	return q, nil
 }
@@ -228,9 +228,9 @@ func readQuery(name string) (*query, error) {
 			return nil, err
 		}
 	} else {
-		qd.query = string(data)
+		qd.Query = string(data)
 	}
-	qd.name = strings.TrimSuffix(filepath.Base(name), filepath.Ext(name))
+	qd.Name = strings.TrimSuffix(filepath.Base(name), filepath.Ext(name))
 
 	return qd, nil
 }

--- a/cmd/report/query_test.go
+++ b/cmd/report/query_test.go
@@ -1,0 +1,92 @@
+package report
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_queryCmdOptions_parseQuery(t *testing.T) {
+	tests := []struct {
+		name             string
+		fieldsFromFlags  *queryCmdOptions
+		fieldsAfterParse *queryCmdOptions
+		want             *query
+		wantErr          assert.ErrorAssertionFunc
+	}{
+		{"template file",
+			&queryCmdOptions{queryOrFile: "testdata/template1.yaml"},
+			&queryCmdOptions{
+				queryOrFile: "testdata/template1.yaml",
+			},
+			&query{
+				Name:        "template1",
+				Description: "Example template\n",
+				Query:       "r.db('veidemann').table('config_crawl_entities')\n",
+				Template:    "{{.id}} {{.meta.name}}\n",
+			},
+			assert.NoError},
+		{"template file with template flag",
+			&queryCmdOptions{
+				queryOrFile: "testdata/template1.yaml",
+				goTemplate:  "{{.id}}",
+			},
+			&queryCmdOptions{
+				queryOrFile: "testdata/template1.yaml",
+				goTemplate:  "{{.id}}",
+			},
+			&query{
+				Name:        "template1",
+				Description: "Example template\n",
+				Query:       "r.db('veidemann').table('config_crawl_entities')\n",
+				Template:    "{{.id}} {{.meta.name}}\n",
+			},
+			assert.NoError},
+		{"template file with format flag",
+			&queryCmdOptions{
+				queryOrFile: "testdata/template1.yaml",
+				format:      "yaml",
+			},
+			&queryCmdOptions{
+				queryOrFile: "testdata/template1.yaml",
+				format:      "yaml",
+			},
+			&query{
+				Name:        "template1",
+				Description: "Example template\n",
+				Query:       "r.db('veidemann').table('config_crawl_entities')\n",
+				Template:    "{{.id}} {{.meta.name}}\n",
+			},
+			assert.NoError},
+		{"nonexisting template file",
+			&queryCmdOptions{
+				queryOrFile: "missing.yaml",
+			},
+			&queryCmdOptions{queryOrFile: "missing.yaml"},
+			nil,
+			assert.Error},
+		{"query",
+			&queryCmdOptions{
+				queryOrFile: "r.db('veidemann').table('config_crawl_entities')",
+			},
+			&queryCmdOptions{
+				queryOrFile: "r.db('veidemann').table('config_crawl_entities')",
+			},
+			&query{
+				Name:        "",
+				Description: "",
+				Query:       "r.db('veidemann').table('config_crawl_entities')",
+				Template:    "",
+			},
+			assert.NoError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fieldsFromFlags.parseQuery()
+			if !tt.wantErr(t, err, "parseQuery()") {
+				return
+			}
+			assert.Equalf(t, tt.fieldsAfterParse, tt.fieldsFromFlags, "Fields after parseQuery()")
+			assert.Equalf(t, tt.want, got, "parseQuery()")
+		})
+	}
+}

--- a/cmd/report/testdata/template1.yaml
+++ b/cmd/report/testdata/template1.yaml
@@ -1,0 +1,8 @@
+description: |
+  Example template
+
+query: |
+  r.db('veidemann').table('config_crawl_entities')
+
+template: |
+  {{.id}} {{.meta.name}}

--- a/format/TemplateFormatter.go
+++ b/format/TemplateFormatter.go
@@ -46,7 +46,7 @@ func newTemplateFormatter(s *MarshalSpec) (Formatter, error) {
 		return nil, err
 	}
 	t.parsedTemplate = pt
-	return t, nil
+	return &preFormatter{t}, nil
 }
 
 // WriteRecord writes a record to the formatters writer
@@ -106,16 +106,6 @@ func parseTemplate(templateString string) (*template.Template, error) {
 				return "                        "
 			} else {
 				return fmt.Sprintf("%-24.24s", ts.AsTime().Format(time.RFC3339))
-			}
-		},
-		"rethinktime": func(ts map[string]interface{}) string {
-			if ts == nil {
-				return "                        "
-			} else {
-				dateTime, _ := ts["dateTime"].(map[string]interface{})
-				date, _ := dateTime["date"].(map[string]interface{})
-				time, _ := dateTime["time"].(map[string]interface{})
-				return fmt.Sprintf("%04.f-%02.f-%02.fT%02.f:%02.f:%02.f", date["year"], date["month"], date["day"], time["hour"], time["minute"], time["second"])
 			}
 		},
 		"json": func(v interface{}) (string, error) {


### PR DESCRIPTION
The command `veidemannctl report query` allows to write raw RethinkDb queries to Veidemanns config database.
When such a query returns a structure containing a date element, it is formatted as it is represented in RethinkDb like this:

```json
{
  "dateTime":{
    "date":{
      "year":2019,
      "month":2,
      "day":21
    },
    "time":{
      "hour":13,
      "minute":29,
      "second":55,
      "nano":324000000
    }
  },
  "offset":{
    "totalSeconds":0
  }
}
```
When the database is accessed with the regular get/set update commands, the format defined by RFC3339 is used. This PR detects RethinkDb dates in query responses and converts them to RFC3339 format.