### PR TITLE
Override query templates with flags

### DIFF
--- a/cmd/report/query.go
+++ b/cmd/report/query.go
@@ -151,15 +151,14 @@ func (o *queryCmdOptions) parseQuery(args []string) (*query, error) {
 	q := &query{
 		queryOrFile: args[0],
 		queryArgs:   make([]any, len(args[1:])),
+		opts:        o,
 	}
 	for i, arg := range args[1:] {
 		q.queryArgs[i] = arg
 	}
 
 	if strings.HasPrefix(q.queryOrFile, "r.") {
-		q = &query{
-			Query: q.queryOrFile,
-		}
+		q.Query = q.queryOrFile
 	} else {
 		filename, err := findQueryFile(q.queryOrFile)
 		if err != nil {
@@ -173,12 +172,12 @@ func (o *queryCmdOptions) parseQuery(args []string) (*query, error) {
 		if o.goTemplate != "" {
 			q.Template = o.goTemplate
 		}
-		if o.format == "" {
-			if q.Template != "" {
-				o.format = "template"
-			} else {
-				o.format = "json"
-			}
+	}
+	if o.format == "" {
+		if q.Template != "" {
+			o.format = "template"
+		} else {
+			o.format = "json"
 		}
 	}
 

--- a/cmd/report/query.go
+++ b/cmd/report/query.go
@@ -32,56 +32,44 @@ import (
 )
 
 type queryCmdOptions struct {
-	queryOrFile string
-	queryArgs   []any
-	pageSize    int32
-	page        int32
-	goTemplate  string
-	file        string
-	format      string
+	pageSize   int32
+	page       int32
+	goTemplate string
+	file       string
+	format     string
 }
 
-func (o *queryCmdOptions) complete(cmd *cobra.Command, args []string) error {
-	o.queryOrFile = args[0]
+// query is a struct for holding query definitions
+type query struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Query       string `json:"query"`
+	Template    string `json:"template"`
 
-	for _, arg := range args[1:] {
-		o.queryArgs = append(o.queryArgs, arg)
-	}
-
-	return nil
+	opts        *queryCmdOptions
+	queryOrFile string
+	queryArgs   []any
+	request     *reportV1.ExecuteDbQueryRequest
 }
 
 // run runs the query command
-func (o *queryCmdOptions) run() error {
-	q, err := o.parseQuery()
-	if err != nil {
-		return fmt.Errorf("failed to parse query: %w", err)
-	}
-
-	request := reportV1.ExecuteDbQueryRequest{
-		Query: q.Query,
-		Limit: o.pageSize,
-	}
-
-	log.Debug().Msgf("Executing query: %s", request.GetQuery())
+func (q *query) run() error {
+	log.Debug().Msgf("Executing query: %s", q.request.GetQuery())
 
 	var w io.Writer
+	var err error
 
-	if o.file == "" || o.file == "-" {
+	if q.opts.file == "" || q.opts.file == "-" {
 		w = os.Stdout
 	} else {
-		w, err = os.Create(o.file)
+		w, err = os.Create(q.opts.file)
 		if err != nil {
-			return fmt.Errorf("failed to create file: %s: %w", o.file, err)
+			return fmt.Errorf("failed to create file: %s: %w", q.opts.file, err)
 		}
 	}
 
 	var formatter format.Formatter
-	if q.Template == "" {
-		formatter, err = format.NewFormatter("", w, o.format, o.goTemplate)
-	} else {
-		formatter, err = format.NewFormatter("", w, "template", q.Template)
-	}
+	formatter, err = format.NewFormatter("", w, q.opts.format, q.Template)
 	if err != nil {
 		return fmt.Errorf("failed to create formatter: %w", err)
 	}
@@ -94,7 +82,7 @@ func (o *queryCmdOptions) run() error {
 
 	client := reportV1.NewReportClient(conn)
 
-	stream, err := client.ExecuteDbQuery(context.Background(), &request)
+	stream, err := client.ExecuteDbQuery(context.Background(), q.request)
 	if err != nil {
 		return fmt.Errorf("failed executing query: %w", err)
 	}
@@ -137,52 +125,67 @@ func newQueryCmd() *cobra.Command {
 			}
 			return names, cobra.ShellCompDirectiveDefault
 		},
-		PreRunE: o.complete,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			q, err := o.parseQuery(args)
+			if err != nil {
+				return fmt.Errorf("failed to parse query: %w", err)
+			}
+
 			// set silence usage to true to avoid printing usage when an error occurs
 			cmd.SilenceUsage = true
 
-			return o.run()
+			return q.run()
 		},
 	}
 
 	cmd.Flags().Int32VarP(&o.pageSize, "pagesize", "s", 10, "Number of objects to get")
 	cmd.Flags().Int32VarP(&o.page, "page", "p", 0, "The page number")
-	cmd.Flags().StringVarP(&o.format, "output", "o", "json", "Output format (json|yaml|template|template-file)")
+	cmd.Flags().StringVarP(&o.format, "output", "o", "", "Output format (json|yaml|template|template-file) (default \"json\")")
 	cmd.Flags().StringVarP(&o.goTemplate, "template", "t", "", "A Go template used to format the output")
 	cmd.Flags().StringVarP(&o.file, "filename", "f", "", "Filename to write to")
 
 	return cmd
 }
 
-// query is a struct for holding query definitions
-type query struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Query       string `json:"query"`
-	Template    string `json:"template"`
-}
+func (o *queryCmdOptions) parseQuery(args []string) (*query, error) {
+	q := &query{
+		queryOrFile: args[0],
+		queryArgs:   make([]any, len(args[1:])),
+	}
+	for i, arg := range args[1:] {
+		q.queryArgs[i] = arg
+	}
 
-func (o *queryCmdOptions) parseQuery() (*query, error) {
-	var q *query
-
-	if strings.HasPrefix(o.queryOrFile, "r.") {
+	if strings.HasPrefix(q.queryOrFile, "r.") {
 		q = &query{
-			Query: o.queryOrFile,
+			Query: q.queryOrFile,
 		}
 	} else {
-		filename, err := findQueryFile(o.queryOrFile)
+		filename, err := findQueryFile(q.queryOrFile)
 		if err != nil {
 			return nil, err
 		}
 		log.Debug().Msgf("Using query definition from file '%s'", filename)
-		q, err = readQuery(filename)
+		err = readQuery(filename, q)
 		if err != nil {
 			return nil, err
 		}
+		if o.goTemplate != "" {
+			q.Template = o.goTemplate
+		}
+		if o.format == "" {
+			if q.Template != "" {
+				o.format = "template"
+			} else {
+				o.format = "json"
+			}
+		}
 	}
 
-	q.Query = fmt.Sprintf(q.Query, o.queryArgs...)
+	q.request = &reportV1.ExecuteDbQueryRequest{
+		Query: fmt.Sprintf(q.Query, q.queryArgs...),
+		Limit: o.pageSize,
+	}
 
 	return q, nil
 }
@@ -215,24 +218,23 @@ func findQueryFile(name string) (string, error) {
 }
 
 // readQuery reads a query definition from a file
-func readQuery(name string) (*query, error) {
+func readQuery(name string, q *query) error {
 	data, err := os.ReadFile(name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %s: %w", name, err)
+		return fmt.Errorf("failed to read file: %s: %w", name, err)
 	}
-	qd := new(query)
 	// Found file
 	if strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml") {
-		err := yaml.Unmarshal(data, qd)
+		err := yaml.Unmarshal(data, q)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	} else {
-		qd.Query = string(data)
+		q.Query = string(data)
 	}
-	qd.Name = strings.TrimSuffix(filepath.Base(name), filepath.Ext(name))
+	q.Name = strings.TrimSuffix(filepath.Base(name), filepath.Ext(name))
 
-	return qd, nil
+	return nil
 }
 
 // listStoredQueries returns a list of query definitions stored in the query directory
@@ -242,11 +244,12 @@ func listStoredQueries(path string) []*query {
 	if files, err := os.ReadDir(path); err == nil {
 		for _, f := range files {
 			if !f.IsDir() {
-				q, err := readQuery(filepath.Join(path, f.Name()))
+				var q query
+				err := readQuery(filepath.Join(path, f.Name()), &q)
 				if err != nil {
 					return nil
 				}
-				r = append(r, q)
+				r = append(r, &q)
 			}
 		}
 	}

--- a/cmd/report/query_test.go
+++ b/cmd/report/query_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	reportV1 "github.com/nlnwa/veidemann-api/go/report/v1"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -9,79 +10,92 @@ func Test_queryCmdOptions_parseQuery(t *testing.T) {
 	tests := []struct {
 		name             string
 		fieldsFromFlags  *queryCmdOptions
+		args             []string
 		fieldsAfterParse *queryCmdOptions
 		want             *query
 		wantErr          assert.ErrorAssertionFunc
 	}{
 		{"template file",
-			&queryCmdOptions{queryOrFile: "testdata/template1.yaml"},
+			&queryCmdOptions{},
+			[]string{"testdata/template1.yaml"},
 			&queryCmdOptions{
-				queryOrFile: "testdata/template1.yaml",
+				format: "template",
 			},
 			&query{
 				Name:        "template1",
 				Description: "Example template\n",
 				Query:       "r.db('veidemann').table('config_crawl_entities')\n",
 				Template:    "{{.id}} {{.meta.name}}\n",
+				queryOrFile: "testdata/template1.yaml",
+				queryArgs:   make([]any, 0),
+				request: &reportV1.ExecuteDbQueryRequest{
+					Query: "r.db('veidemann').table('config_crawl_entities')\n",
+				},
 			},
 			assert.NoError},
 		{"template file with template flag",
 			&queryCmdOptions{
-				queryOrFile: "testdata/template1.yaml",
-				goTemplate:  "{{.id}}",
+				goTemplate: "{{.id}}",
 			},
+			[]string{"testdata/template1.yaml"},
 			&queryCmdOptions{
-				queryOrFile: "testdata/template1.yaml",
-				goTemplate:  "{{.id}}",
+				goTemplate: "{{.id}}",
+				format:     "template",
 			},
 			&query{
 				Name:        "template1",
 				Description: "Example template\n",
 				Query:       "r.db('veidemann').table('config_crawl_entities')\n",
-				Template:    "{{.id}} {{.meta.name}}\n",
+				Template:    "{{.id}}",
+				queryOrFile: "testdata/template1.yaml",
+				queryArgs:   make([]any, 0),
+				request: &reportV1.ExecuteDbQueryRequest{
+					Query: "r.db('veidemann').table('config_crawl_entities')\n",
+				},
 			},
 			assert.NoError},
 		{"template file with format flag",
 			&queryCmdOptions{
-				queryOrFile: "testdata/template1.yaml",
-				format:      "yaml",
+				format: "yaml",
 			},
+			[]string{"testdata/template1.yaml"},
 			&queryCmdOptions{
-				queryOrFile: "testdata/template1.yaml",
-				format:      "yaml",
+				format: "yaml",
 			},
 			&query{
 				Name:        "template1",
 				Description: "Example template\n",
 				Query:       "r.db('veidemann').table('config_crawl_entities')\n",
 				Template:    "{{.id}} {{.meta.name}}\n",
+				queryOrFile: "testdata/template1.yaml",
+				queryArgs:   make([]any, 0),
+				request: &reportV1.ExecuteDbQueryRequest{
+					Query: "r.db('veidemann').table('config_crawl_entities')\n",
+				},
 			},
 			assert.NoError},
 		{"nonexisting template file",
-			&queryCmdOptions{
-				queryOrFile: "missing.yaml",
-			},
-			&queryCmdOptions{queryOrFile: "missing.yaml"},
+			&queryCmdOptions{},
+			[]string{"missing.yaml"},
+			&queryCmdOptions{},
 			nil,
 			assert.Error},
 		{"query",
-			&queryCmdOptions{
-				queryOrFile: "r.db('veidemann').table('config_crawl_entities')",
-			},
-			&queryCmdOptions{
-				queryOrFile: "r.db('veidemann').table('config_crawl_entities')",
-			},
+			&queryCmdOptions{},
+			[]string{"r.db('veidemann').table('config_crawl_entities')"},
+			&queryCmdOptions{},
 			&query{
-				Name:        "",
-				Description: "",
-				Query:       "r.db('veidemann').table('config_crawl_entities')",
-				Template:    "",
+				Query: "r.db('veidemann').table('config_crawl_entities')",
+				request: &reportV1.ExecuteDbQueryRequest{
+					Query: "r.db('veidemann').table('config_crawl_entities')",
+				},
 			},
 			assert.NoError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.fieldsFromFlags.parseQuery()
+			o := tt.fieldsFromFlags
+			got, err := o.parseQuery(tt.args)
 			if !tt.wantErr(t, err, "parseQuery()") {
 				return
 			}

--- a/cmd/report/query_test.go
+++ b/cmd/report/query_test.go
@@ -8,19 +8,15 @@ import (
 
 func Test_queryCmdOptions_parseQuery(t *testing.T) {
 	tests := []struct {
-		name             string
-		fieldsFromFlags  *queryCmdOptions
-		args             []string
-		fieldsAfterParse *queryCmdOptions
-		want             *query
-		wantErr          assert.ErrorAssertionFunc
+		name            string
+		fieldsFromFlags *queryCmdOptions
+		args            []string
+		want            *query
+		wantErr         assert.ErrorAssertionFunc
 	}{
 		{"template file",
 			&queryCmdOptions{},
 			[]string{"testdata/template1.yaml"},
-			&queryCmdOptions{
-				format: "template",
-			},
 			&query{
 				Name:        "template1",
 				Description: "Example template\n",
@@ -31,6 +27,9 @@ func Test_queryCmdOptions_parseQuery(t *testing.T) {
 				request: &reportV1.ExecuteDbQueryRequest{
 					Query: "r.db('veidemann').table('config_crawl_entities')\n",
 				},
+				opts: &queryCmdOptions{
+					format: "template",
+				},
 			},
 			assert.NoError},
 		{"template file with template flag",
@@ -38,10 +37,6 @@ func Test_queryCmdOptions_parseQuery(t *testing.T) {
 				goTemplate: "{{.id}}",
 			},
 			[]string{"testdata/template1.yaml"},
-			&queryCmdOptions{
-				goTemplate: "{{.id}}",
-				format:     "template",
-			},
 			&query{
 				Name:        "template1",
 				Description: "Example template\n",
@@ -52,6 +47,10 @@ func Test_queryCmdOptions_parseQuery(t *testing.T) {
 				request: &reportV1.ExecuteDbQueryRequest{
 					Query: "r.db('veidemann').table('config_crawl_entities')\n",
 				},
+				opts: &queryCmdOptions{
+					goTemplate: "{{.id}}",
+					format:     "template",
+				},
 			},
 			assert.NoError},
 		{"template file with format flag",
@@ -59,9 +58,6 @@ func Test_queryCmdOptions_parseQuery(t *testing.T) {
 				format: "yaml",
 			},
 			[]string{"testdata/template1.yaml"},
-			&queryCmdOptions{
-				format: "yaml",
-			},
 			&query{
 				Name:        "template1",
 				Description: "Example template\n",
@@ -72,22 +68,28 @@ func Test_queryCmdOptions_parseQuery(t *testing.T) {
 				request: &reportV1.ExecuteDbQueryRequest{
 					Query: "r.db('veidemann').table('config_crawl_entities')\n",
 				},
+				opts: &queryCmdOptions{
+					format: "yaml",
+				},
 			},
 			assert.NoError},
 		{"nonexisting template file",
 			&queryCmdOptions{},
 			[]string{"missing.yaml"},
-			&queryCmdOptions{},
 			nil,
 			assert.Error},
 		{"query",
 			&queryCmdOptions{},
 			[]string{"r.db('veidemann').table('config_crawl_entities')"},
-			&queryCmdOptions{},
 			&query{
-				Query: "r.db('veidemann').table('config_crawl_entities')",
+				Query:       "r.db('veidemann').table('config_crawl_entities')",
+				queryOrFile: "r.db('veidemann').table('config_crawl_entities')",
+				queryArgs:   make([]any, 0),
 				request: &reportV1.ExecuteDbQueryRequest{
 					Query: "r.db('veidemann').table('config_crawl_entities')",
+				},
+				opts: &queryCmdOptions{
+					format: "json",
 				},
 			},
 			assert.NoError},
@@ -99,7 +101,6 @@ func Test_queryCmdOptions_parseQuery(t *testing.T) {
 			if !tt.wantErr(t, err, "parseQuery()") {
 				return
 			}
-			assert.Equalf(t, tt.fieldsAfterParse, tt.fieldsFromFlags, "Fields after parseQuery()")
 			assert.Equalf(t, tt.want, got, "parseQuery()")
 		})
 	}


### PR DESCRIPTION
Let command line flags for template and format have preference to definitions in stored queries