### PR TITLE
Fix nil pointer exception

### DIFF
--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -144,6 +144,7 @@ func run(o *options) error {
 		r, err := client.DeleteConfigObject(context.Background(), request)
 		if err != nil {
 			log.Error().Err(err).Str("id", msg.Id).Msgf("Could not delete object")
+			continue
 		}
 		if r.Deleted {
 			deleted++


### PR DESCRIPTION
This commit fixes a nil pointer exception that occurs if delete fails. The code is trying to access r which is nil in case of such error.