### PR TITLE
feat: Authorization Code Flow with PKCE

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ func GetApiKeyConfig() (*ApiKeyConfig, error) {
 // OIDCConfig is the configuration for the oidc authentication provider.
 type OIDCConfig struct {
 	ClientID     string `yaml:"client-id" mapstructure:"client-id"`
-	ClientSecret string `yaml:"client-secret" mapstructure:"client-secret"`
+	ClientSecret string `yaml:"client-secret,omitempty" mapstructure:"client-secret"`
 	IdToken      string `yaml:"id-token" mapstructure:"id-token"`
 	RefreshToken string `yaml:"refresh-token,omitempty" mapstructure:"refresh-token"`
 	IdpIssuerUrl string `yaml:"idp-issuer-url" mapstructure:"idp-issuer-url"`

--- a/connection/auth.go
+++ b/connection/auth.go
@@ -87,7 +87,7 @@ func loginOIDC(oidcConfig *config.OIDCConfig, manualLogin bool) (*claims, error)
 	// Does the provider use "offline_access" scope to request a refresh token
 	// or does it use "access_type=offline" (e.g. Google)?
 	offlineAsScope := false
-	scopes := []string{oidc.ScopeOpenID, "profile", "email", "groups", "audience:server:client_id:veidemann-api"}
+	scopes := []string{oidc.ScopeOpenID, "profile", "email", "groups"}
 	if offlineAsScope {
 		scopes = append(scopes, "offline_access")
 	}

--- a/connection/auth.go
+++ b/connection/auth.go
@@ -123,7 +123,7 @@ func loginOIDC(oidcConfig *config.OIDCConfig, manualLogin bool) (*claims, error)
 		Config: config.OIDCConfig{
 			ClientID:     o.clientID,
 			ClientSecret: o.clientSecret,
-			IdToken:      o.rawIdToken,
+			IdToken:      o.idToken,
 			RefreshToken: o.refreshToken,
 			IdpIssuerUrl: o.idpIssuerUrl,
 		},
@@ -170,7 +170,7 @@ func getIdpIssuer() (string, error) {
 type oidcProvider struct {
 	clientID     string
 	clientSecret string
-	rawIdToken   string
+	idToken      string
 	refreshToken string
 	idpIssuerUrl string
 	scopes       []string
@@ -255,10 +255,10 @@ func (op *oidcProvider) login(manual bool) (*claims, error) {
 	if !ok {
 		return nil, errors.New("token not found")
 	}
-	op.rawIdToken = rawIDToken
+	op.idToken = rawIDToken
 
 	// Parse and verify ID Token payload.
-	idToken, err := idTokenVerifier.Verify(ctx, op.rawIdToken)
+	idToken, err := idTokenVerifier.Verify(ctx, rawIDToken)
 	if err != nil {
 		return nil, err
 	}

--- a/connection/auth.go
+++ b/connection/auth.go
@@ -83,9 +83,7 @@ func loginOIDC(oidcConfig *config.OIDCConfig, manualLogin bool) (*claims, error)
 		clientID = "veidemann-cli"
 	}
 	clientSecret := oidcConfig.ClientSecret
-	if clientSecret == "" {
-		clientSecret = "cli-app-secret"
-	}
+
 	// Does the provider use "offline_access" scope to request a refresh token
 	// or does it use "access_type=offline" (e.g. Google)?
 	offlineAsScope := false

--- a/connection/auth.go
+++ b/connection/auth.go
@@ -198,7 +198,6 @@ func (op *oidcProvider) login(manual bool) (*claims, error) {
 	}
 	idTokenVerifier = p.Verifier(&oc)
 
-
 	// create nonce and use nonce as state
 	nonce := randStringBytesMaskImprSrc(16)
 	state := nonce
@@ -235,7 +234,6 @@ func (op *oidcProvider) login(manual bool) (*claims, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	op.refreshToken = oauth2Token.RefreshToken
 
 	// Extract the ID Token from OAuth2 token.
@@ -245,12 +243,13 @@ func (op *oidcProvider) login(manual bool) (*claims, error) {
 	}
 	op.idToken = rawIDToken
 
-	// Parse and verify ID Token payload.
+	// Verify ID Token
 	idToken, err := idTokenVerifier.Verify(ctx, rawIDToken)
 	if err != nil {
 		return nil, err
 	}
 
+	// Verify nonce
 	if idToken.Nonce != nonce {
 		return nil, errors.New("nonce did not match")
 	}

--- a/connection/auth.go
+++ b/connection/auth.go
@@ -192,10 +192,12 @@ func (op *oidcProvider) login(manual bool) (*claims, error) {
 	p, err := oidc.NewProvider(ctx, op.idpIssuerUrl)
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to identity provider \"%s\": %w", op.idpIssuerUrl, err)
-	} else {
-		oc := oidc.Config{ClientID: op.clientID}
-		idTokenVerifier = p.Verifier(&oc)
 	}
+	oc := oidc.Config{
+		ClientID: op.clientID,
+	}
+	idTokenVerifier = p.Verifier(&oc)
+
 
 	// create nonce and use nonce as state
 	nonce := randStringBytesMaskImprSrc(16)


### PR DESCRIPTION
This PR implements Authorization Code Flow **with Proof Key for Code Exchange (PKCE)**.

> PKCE was originally designed to protect the authorization code flow in mobile  apps, but its ability to prevent authorization code injection makes it useful for every type of OAuth client, even web apps that use client authentication.

https://oauth.net/2/pkce/

This PR also seeks to standardise the OIDC login flow such that specifics about a particular authorization server implementation is removed.


