### PR TITLE
Fix nil pointer exception when veidemann is configured without auth

### DIFF
--- a/connection/auth.go
+++ b/connection/auth.go
@@ -67,6 +67,9 @@ func Login(manualLogin bool) error {
 		if err != nil {
 			return err
 		}
+		if claims == nil {
+			return nil
+		}
 		fmt.Printf("Hello, %s!\n", claims.Name)
 	case config.ProviderApiKey:
 		// no login procedure for apikey


### PR DESCRIPTION
This commit fixes a nil pointer exception that triggers if no idp issuer is returned from veidemann-controller.