### PR TITLE
Revert "refactor: remove non-standard scope"

### DIFF
--- a/connection/auth.go
+++ b/connection/auth.go
@@ -90,7 +90,7 @@ func loginOIDC(oidcConfig *config.OIDCConfig, manualLogin bool) (*claims, error)
 	// Does the provider use "offline_access" scope to request a refresh token
 	// or does it use "access_type=offline" (e.g. Google)?
 	offlineAsScope := false
-	scopes := []string{oidc.ScopeOpenID, "profile", "email", "groups"}
+	scopes := []string{oidc.ScopeOpenID, "profile", "email", "groups", "audience:server:client_id:veidemann-api"}
 	if offlineAsScope {
 		scopes = append(scopes, "offline_access")
 	}


### PR DESCRIPTION
This reverts commit defe6919b987e6e69a7d4a5734148864cc8f3001.

In veidemann dex will act is a shim between clients and upstream identity providers. This means that veidemann-cli and veidemann-dashboard is configured against dex specifially.

The scope "audience:server:client_id:veidemann-api" makes dex add "veidemann-api" (in addition to client id) to the "aud" (audience) field of the identity and access token. Veidemann controller checks the "aud" field and only accepts tokens that have "veidemann-api" as audience.

See https://dexidp.io/docs/custom-scopes-claims-clients/#cross-client-trust-and-authorized-party